### PR TITLE
feat(ingest): ON CONFLICT DO UPDATE for phase metrics backfill

### DIFF
--- a/.github/workflows/historical-backfill.yml
+++ b/.github/workflows/historical-backfill.yml
@@ -116,3 +116,8 @@ jobs:
           echo "═══════════════════════════════════════════════════"
           echo "  ✅ All chunks complete!"
           echo "═══════════════════════════════════════════════════"
+
+      - name: Refresh materialized views
+        run: |
+          echo "Refreshing mv_hourly_usage (Govern stage)..."
+          python backend/python_scripts/govern/refresh_views.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Argo Energy Solutions will be documented in this file.
 
+## [2026-02-16] — Phase metrics backfill support (stage: Ingest / Govern)
+- Changed `ingest_to_postgres.py` from `ON CONFLICT DO NOTHING` to `ON CONFLICT DO UPDATE SET` for readings
+- Enables re-ingestion to update existing rows with phase metrics (V1–V3, I1–I3, neutral current, THD, frequency, etc.) that were null before the electrical health fields were added
+- Added refresh of `mv_hourly_usage` to historical-backfill workflow (Govern step) after ingestion completes
+- **To backfill phase data (2025-04-29 → 2026-01-14):** Run "Historical backfill" workflow with START_DATE=2025-04-29, END_DATE=2026-01-14; the workflow now updates existing rows and refreshes materialized views
+
 ## [2026-02-15] — Fix v_clean_readings view column conflict (stage: Govern)
 - Fixed `npm run db:views` failing with "cannot change name of view column 'created_at' to 'frequency_hz'"
 - Updated `create-layered-views.sql`: drop `mv_hourly_usage` before `v_clean_readings` so the view can be dropped cleanly; use `CREATE VIEW` instead of `CREATE OR REPLACE` for v_clean_readings (PostgreSQL cannot rename columns via REPLACE)

--- a/backend/python_scripts/ingest/ingest_to_postgres.py
+++ b/backend/python_scripts/ingest/ingest_to_postgres.py
@@ -629,7 +629,33 @@ class PostgresDB:
                         )
                         VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
                                 %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                        ON CONFLICT (channel_id, timestamp) DO NOTHING
+                        ON CONFLICT (channel_id, timestamp) DO UPDATE SET
+                            energy_kwh = EXCLUDED.energy_kwh,
+                            power_kw = EXCLUDED.power_kw,
+                            voltage_v = EXCLUDED.voltage_v,
+                            current_a = EXCLUDED.current_a,
+                            power_factor = EXCLUDED.power_factor,
+                            reactive_power_kvar = EXCLUDED.reactive_power_kvar,
+                            apparent_power_va = EXCLUDED.apparent_power_va,
+                            frequency_hz = EXCLUDED.frequency_hz,
+                            thd_current = EXCLUDED.thd_current,
+                            neutral_current_a = EXCLUDED.neutral_current_a,
+                            cost = EXCLUDED.cost,
+                            voltage_v1 = EXCLUDED.voltage_v1,
+                            voltage_v2 = EXCLUDED.voltage_v2,
+                            voltage_v3 = EXCLUDED.voltage_v3,
+                            current_a1 = EXCLUDED.current_a1,
+                            current_a2 = EXCLUDED.current_a2,
+                            current_a3 = EXCLUDED.current_a3,
+                            power_w1 = EXCLUDED.power_w1,
+                            power_w2 = EXCLUDED.power_w2,
+                            power_w3 = EXCLUDED.power_w3,
+                            power_factor_1 = EXCLUDED.power_factor_1,
+                            power_factor_2 = EXCLUDED.power_factor_2,
+                            power_factor_3 = EXCLUDED.power_factor_3,
+                            energy_wh1 = EXCLUDED.energy_wh1,
+                            energy_wh2 = EXCLUDED.energy_wh2,
+                            energy_wh3 = EXCLUDED.energy_wh3
                     """, valid_batch)
 
                     inserted += cur.rowcount


### PR DESCRIPTION
Phase metrics backfill support
Summary
Backfill support for phase metrics (V1–V3, I1–I3, neutral current, THD, frequency, cost, etc.). Existing readings from before these fields were added currently remain null because ingestion uses ON CONFLICT DO NOTHING, which skips inserts when a row already exists.
Changes
ingest_to_postgres.py (Stage: Ingest)
Switched from ON CONFLICT (channel_id, timestamp) DO NOTHING to ON CONFLICT DO UPDATE SET.
Existing rows are now updated with new phase and electrical-health data when re-ingested instead of being skipped.
historical-backfill.yml (Stage: Govern)
Added a “Refresh materialized views” step after ingestion.
Ensures mv_hourly_usage is refreshed after each backfill run.
CHANGELOG.md
Documented the change and backfill procedure.
How to backfill phase data
Merge this PR.
Go to Actions → Historical backfill → Run workflow.
Use:
START_DATE: 2025-04-29
END_DATE: 2026-01-14
SITE_ID: 23271
WCDS_ONLY: true
CHUNK_SIZE_DAYS: 30
Run the workflow; it will update existing readings and refresh materialized views.
Testing
[ ] Run the Historical backfill workflow on a short range (e.g. 2–3 days) and confirm it finishes without errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Phase metrics backfill support now available for re-ingesting historical data
  * Duplicate records are updated during ingestion instead of being skipped

* **Chores**
  * Materialized views automatically refresh after historical backfill operations complete

<!-- end of auto-generated comment: release notes by coderabbit.ai -->