### PR TITLE
Fix section header/content overlap on pages 4-7

### DIFF
--- a/backend/python_reports/scripts/generate_electrical_health_report.py
+++ b/backend/python_reports/scripts/generate_electrical_health_report.py
@@ -353,7 +353,9 @@ class ElectricalHealthPDF(FPDF):
             badge_x = self.get_x()
             badge_y = self.get_y()
             self.cell(50, 10, '', 0, 1, 'L', fill=True)  # Fill rest of bar
+            bottom_y = self.get_y()  # save Y below the bar before _traffic_light resets cursor
             self._traffic_light(status, badge_x + 1, badge_y, w=48, h=10)
+            self.set_y(bottom_y)  # restore; _traffic_light called set_xy() inside
         else:
             self.cell(0, 10, f'  {title}', 0, 1, 'L', fill=True)
         self.set_text_color(*ARGO_DARK)


### PR DESCRIPTION
_traffic_light() calls self.set_xy(x, y+3) internally, which resets the cursor Y to badge_y+3 (inside the 10mm navy bar). The subsequent ln(4) only reached badge_y+7, still inside the bar, so _write_paragraph() was printing text overlapping the section header on all four section pages.

Fix: save bottom_y = self.get_y() after the line-advancing cell (where Y = badge_y+10, below the bar), then restore it with self.set_y(bottom_y) after _traffic_light() returns.

https://claude.ai/code/session_01CGotvjfJRypHGV5nzwRzLr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a layout alignment issue in report section headers when status badges are displayed, ensuring consistent positioning of subsequent content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->